### PR TITLE
fixed /docs route by fixing profile list endpoint params

### DIFF
--- a/api/profiles/routes.py
+++ b/api/profiles/routes.py
@@ -52,7 +52,7 @@ async def add_profiles(
     response_description="List all profiles of department and role",
     response_model=Response
 )
-async def list_public_profiles(department: Department, role=Role):
+async def list_public_profiles(department: Department, role: Role):
     profiles = await retrieve_public_profiles(department=department, role=role)
     return {
         "status_code": 200,
@@ -64,7 +64,6 @@ async def list_public_profiles(department: Department, role=Role):
 
 # TODO PATCH multiple profiles
 # TODO DELETE multiple profiles
-
 
 # single profile operations --------------------------------------------------#
 @router.post(
@@ -154,6 +153,7 @@ async def update_profile(
         else:
             return False
 
+
 # testing for frontend connection---------------------------------------------#
 @router.post(
     "/test/checkrole",
@@ -175,6 +175,7 @@ async def test1(session : SessionContainer = Depends(verify_session())):
             "description": "check role",
             "data": "check completed",
         }
+
 
 # add role to session user for testing ---------------------------------------#
 @router.post(


### PR DESCRIPTION
It took me quite some time to spot that line 55 in the list profiles endpoint used a default argument instead of a type declaration causing issues when generating the automated openapi specs.