### PR TITLE
fix: Links not redirecting correctly

### DIFF
--- a/app/app/review/_components/applicationOverview.tsx
+++ b/app/app/review/_components/applicationOverview.tsx
@@ -79,9 +79,15 @@ interface TallyFieldCompProps {
 }
 const TallyFieldComp = ({ field }: TallyFieldCompProps) => {
   if (field.type === "INPUT_LINK") {
+    const fieldValue = field.value as string;
+    const redirectLink =
+      fieldValue.startsWith("https://") || fieldValue.startsWith("http://")
+        ? fieldValue
+        : `https://${fieldValue}`;
+
     return (
       <div>
-        <Link className="text-blue-500 underline" href={field.value as string}>
+        <Link className="text-blue-500 underline" href={redirectLink}>
           {field.label}
         </Link>
       </div>


### PR DESCRIPTION
### Issue
---
Issue was that when a user submitted a Link to e.g. Linkedin not containing `https://` or `http://`, the href was interpreted as a local link (e.g. `space.tum-ai.com/review/linkToLinkedInSentByUser`)

Example: https://space.tum-ai.com/review/review/?id=267

### Fix
---
Add `https://` when it does not exist for a specific link