### PR TITLE
feat: improve database schema to suit modular phase review management of opportunities

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -40,7 +40,7 @@ model User {
   departmentMemberships    DepartmentMembership[]
   createdOpportunities     Opportunity[]
   opportunityParticipation OpportunityParticipation[]
-  reviews                  Review[]
+  reviews                  PhaseReview[]
   emailVerified            DateTime?
   createdAt                DateTime                   @default(now())
   updatedAt                DateTime                   @updatedAt
@@ -145,6 +145,7 @@ model Opportunity {
   creator                  User?                      @relation(fields: [creatorId], references: [id], onDelete: SetNull)
   title                    String
   description              String
+  configuration            Json
   departmentId             Int
   department               Department                 @relation(fields: [departmentId], references: [id])
   opportunityStart         DateTime
@@ -192,14 +193,26 @@ model Application {
 }
 
 model Review {
-  id            Int         @id @default(autoincrement())
+  id            Int           @id @default(autoincrement())
   opportunityId Int
-  opportunity   Opportunity @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
-  assigneeId    Int
-  assignee      User        @relation(fields: [assigneeId], references: [profileId])
+  opportunity   Opportunity   @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
   applicationId Int
-  application   Application @relation(fields: [applicationId], references: [id])
-  reviewText    String?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
+  application   Application   @relation(fields: [applicationId], references: [id])
+  phaseReviews  PhaseReview[]
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  @@unique([opportunityId, applicationId])
+}
+
+model PhaseReview {
+  id         Int    @id @default(autoincrement())
+  phase      String
+  reviewId   Int
+  review     Review @relation(fields: [reviewId], references: [id])
+  assigneeId Int
+  assignee   User   @relation(fields: [assigneeId], references: [profileId])
+  content    Json
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  @@unique([phase, reviewId])
 }


### PR DESCRIPTION
Based on discussions, this pull request entails these changes:
- Opportunity: Configurations (json) within each opportunity
- Application: Storing applications for these opportunities (*-1)
- Review: Storing reviews to applications (1-*) - for referencing all phase reviews and linking all phase reviews to one entire review
- PhaseReview: Representing the review of a particular phase that is defined in the config of an opportunity. I.e. multiple phaseReviews for one entire review of an application (*-1)