### PR TITLE
feat: Add CRUD operations for review tag endpoints

### DIFF
--- a/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewPhase/[phase]/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewPhase/[phase]/route.ts
@@ -1,113 +1,129 @@
 import { NextRequest, NextResponse } from "next/server";
-import { validateReviewPhaseRequest } from "../route";
-import { updatePhoneNumber } from "firebase/auth";
+import prisma from "database/db";
 
 /**
  * GET opportunity/[opportunityId]/review/[reviewId]/reviewPhase/[phase]
  *
+ * Gets a specific ReviewPhase for a review
+ * 
  * @param NextRequest request
  * @param number opportunityId
  * @param number reviewId
  * @param string phase
- * @returns ReviewPhase reviewPhase
+ * @returns NextResponse
  */
 export const GET = async (
   request: NextRequest,
   { params: { opportunityId, reviewId, phase } },
 ): Promise<NextResponse> => {
   try {
-    const isReviewPhaseRequestValid = await validateReviewPhaseRequest(
-      parseInt(opportunityId),
-      parseInt(reviewId),
-    );
-    const readReviewPhaseByName = await prisma.phaseReview.findUnique({
+    const reviewIdNum = parseInt(reviewId);
+    if (isNaN(reviewIdNum)) {
+      return NextResponse.json({ Error: "Invalid review ID." }, { status: 400 });
+    }
+
+    const reviewPhase = await prisma.phaseReview.findUnique({
       where: {
         id: {
-          reviewId: parseInt(reviewId),
+          reviewId: reviewIdNum,
           phase: phase,
         },
       },
     });
 
-    const responseBody =
-      readReviewPhaseByName === null || !isReviewPhaseRequestValid
-        ? {
-            Error: "Bad request. The review phase with this id does not exist.",
-          }
-        : readReviewPhaseByName;
-    const status =
-      readReviewPhaseByName === null || !isReviewPhaseRequestValid ? 400 : 200;
+    if (!reviewPhase) {
+      return NextResponse.json({ Error: "Review phase does not exist." }, { status: 404 });
+    }
 
-    return NextResponse.json(responseBody, { status });
+    return NextResponse.json(reviewPhase, { status: 200 });
   } catch (error) {
-    console.log(error);
-    return NextResponse.json(
-      { Error: "Internal Server Error" },
-      { status: 500 },
-    );
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
   }
 };
 
 /**
  * UPDATE opportunity/[opportunityId]/review/[reviewId]/reviewPhase/[phase]
  *
+ * Update a ReviewPhase of a review
+ * 
  * @param NextRequest request
  * @param number opportunityId
  * @param number reviewId
  * @param string phase
- * @returns ReviewPhase reviewPhase
+ * @param @async newPhaseName  - the new name of the phase
+ * @param @async assigneeId - the new reviewerId of this phase (refers to User ID)
+ * @returns NextResponse
  */
 export const PUT = async (
   request: NextRequest,
   { params: { opportunityId, reviewId, phase } },
 ): Promise<NextResponse> => {
   try {
-    const isReviewPhaseRequestValid = await validateReviewPhaseRequest(
-      parseInt(opportunityId),
-      parseInt(reviewId),
-    );
+    const reviewIdNum = parseInt(reviewId);
+    const { newPhaseName, assigneeId } = await request.json();
 
-    const { phaseName, assigneeId } = await request.json();
+    if (!newPhaseName || !assigneeId) {
+      return NextResponse.json({ Error: "New phase name and valid assignee ID are required." }, { status: 400 });
+    }
 
-    const updateReviewPhase = await prisma.phaseReview.update({
+    const assigneeExists = await prisma.user.findUnique({
+      where: {
+        id: assigneeId
+      },
+    });
+
+    if (!assigneeExists) {
+      return NextResponse.json({ Error: "Assignee does not exist." }, { status: 404 });
+    }
+
+    const existingPhaseReview = await prisma.phaseReview.findUnique({
       where: {
         id: {
+          reviewId: reviewIdNum,
           phase: phase,
-          reviewId: parseInt(reviewId),
+        },
+      },
+    });
+
+    if (!existingPhaseReview) {
+      return NextResponse.json({ Error: "Review phase not found." }, { status: 404 });
+    }
+
+    const updatedReviewPhase = await prisma.phaseReview.update({
+      where: {
+        id: { 
+          phase,
+          reviewId: reviewIdNum,
         },
       },
       data: {
-        phase: phaseName,
+        phase: newPhaseName,
         assigneeId: assigneeId,
       },
     });
 
-    const responseBody =
-      updateReviewPhase === null || !isReviewPhaseRequestValid
-        ? {
-            Error: "Bad request. The review phase with this id does not exist.",
-          }
-        : updateReviewPhase;
-    const status =
-      updateReviewPhase === null ||
-      !isReviewPhaseRequestValid ||
-      (phase === undefined && assigneeId === undefined)
-        ? 400
-        : 200;
-
-    return NextResponse.json(responseBody, { status });
+    return NextResponse.json(updatedReviewPhase, { status: 200 });
   } catch (error) {
-    console.log(error);
-    return NextResponse.json(
-      { Error: "Internal Server Error" },
-      { status: 500 },
-    );
+    console.error(error);
+
+    if (error.code === "P2025") {
+      return NextResponse.json({ Error: "Review phase not found." }, { status: 404 });
+    } else if (error.code === "P2002") {
+      return NextResponse.json({ Error: "Data constraint violation." }, { status: 400 });
+    }
+
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
   }
 };
+
+
 
 /**
  * DELETE opportunity/[opportunityId]/review/[reviewId]/reviewPhase/[phase]
  *
+ * Remove a ReviewPhase for a review
+ * 
  * @param NextRequest request
  * @param number opportunityId
  * @param number reviewId
@@ -119,37 +135,24 @@ export const DELETE = async (
   { params: { opportunityId, reviewId, phase } },
 ): Promise<NextResponse> => {
   try {
-    const isReviewPhaseRequestValid = await validateReviewPhaseRequest(
-      parseInt(opportunityId),
-      parseInt(reviewId),
-    );
+    const reviewIdNum = parseInt(reviewId);
 
-    const deleteReviewPhase = await prisma.phaseReview.delete({
+    await prisma.phaseReview.delete({
       where: {
         id: {
+          reviewId: reviewIdNum,
           phase: phase,
-          reviewId: parseInt(reviewId),
         },
       },
     });
 
-    const responseBody =
-      deleteReviewPhase === null || isReviewPhaseRequestValid === undefined
-        ? {
-            Error: "Bad request. The review phase with this id does not exist.",
-          }
-        : deleteReviewPhase;
-    const status =
-      deleteReviewPhase === null || isReviewPhaseRequestValid === undefined
-        ? 400
-        : 200;
-
-    return NextResponse.json(responseBody, { status });
+    return NextResponse.json({ Message: "Review phase deleted successfully." }, { status: 200 });
   } catch (error) {
-    console.log(error);
-    return NextResponse.json(
-      { Error: "Internal Server Error" },
-      { status: 500 },
-    );
+    console.error(error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ Error: "Review phase not found." }, { status: 404 });
+    }
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
   }
 };
+

--- a/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewPhase/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewPhase/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkOpportunityExistence } from "../../route";
-import { validateLocaleAndSetLanguage } from "typescript";
 
 /**
  * Checks if the review exists.
@@ -24,16 +23,27 @@ export const checkReviewExistence = async (
   return review !== null;
 };
 
+/**
+ * Ensures that the opportunity and review ids exist.
+ *
+ * @param opportunityId
+ *
+ * @param reviewId
+ * @returns
+ */
 export const validateReviewPhaseRequest = async (
   opportunityId: number,
   reviewId: number,
 ): Promise<boolean> => {
   try {
     return (
-      checkOpportunityExistence(opportunityId) && checkReviewExistence(reviewId)
+      (await checkOpportunityExistence(opportunityId)) &&
+      (await checkReviewExistence(reviewId))
     );
   } catch (error) {
-    console.log("Unable to validate review phase request.");
+    console.log(
+      "Unable to validate review request. Does the review/opportunity exist?",
+    );
     return false;
   }
 };
@@ -102,7 +112,6 @@ export const POST = async (
       assigneeId === undefined ||
       content === undefined
     ) {
-      console.log("seaseaesasersaeaseasd\n\n\n\n\n");
       reviewPhaseUndefined = true;
     }
 

--- a/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewTag/[tag]/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewTag/[tag]/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateReviewTagRequest } from "../route";
+
+/**
+ * Validates the existence of an opportunity and a review, then fetches the ID of a given tag.
+ * 
+ * @param {number} opportunityId - The ID of the opportunity to validate.
+ * @param {number} reviewId - The ID of the review to validate.
+ * @param {string} tagName - The name of the tag to fetch the ID for.
+ * @returns {Promise<number>} The ID of the tag.
+ * @throws {Error} If the opportunity, review, or tag does not exist.
+ */
+async function validateAndFetchTagId(opportunityId, reviewId, tagName) {
+  const isValid = await validateReviewTagRequest(parseInt(opportunityId), parseInt(reviewId));
+  if (!isValid) {
+    throw new Error("Invalid opportunity ID or review ID.");
+  }
+
+  const tag = await prisma.tag.findFirst({
+    where: {
+      opportunityId: parseInt(opportunityId),
+      name: tagName,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!tag) {
+    throw new Error(`Tag with name '${tagName}' not found for opportunity ID ${opportunityId}.`);
+  }
+
+  return tag.id;
+}
+
+
+/**
+ * GET opportunity/[opportunityId]/review/[reviewId]/ReviewTag/[tag]
+ * 
+ * Get a ReviewTag for a specific review
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @param number reviewId
+ * @param string tag - this is the tag that is assigned to the reviewTag
+ * @returns NextResponse
+ */
+export const GET = async (
+  request: NextRequest,
+  { params: { opportunityId, reviewId, tag } },
+): Promise<NextResponse> => {
+  try {
+    const tagId = await validateAndFetchTagId(opportunityId, reviewId, tag);
+
+    const reviewTag = await prisma.reviewTag.findFirst({
+      where: {
+        tagId: tagId,
+        reviewId: parseInt(reviewId),
+      },
+      include: {
+        tag: true,
+      },
+    });
+
+    if (!reviewTag) {
+      return NextResponse.json({ Error: "Review tag not found." }, { status: 404 });
+    }
+
+    return NextResponse.json(reviewTag, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: error.message }, { status: 500 });
+  }
+};
+
+
+/**
+ * UPDATE opportunity/[opportunityId]/review/[reviewId]/ReviewTag/[tag]
+ * 
+ * Update the tag of a ReviewTag for a specific review
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @param number reviewId
+ * @param string tag
+ * @param json newTag
+ * @returns NextResponse
+ */
+export const PUT = async (
+  request: NextRequest,
+  { params: { opportunityId, reviewId, tag } },
+): Promise<NextResponse> => {
+  try {
+    const tagId = await validateAndFetchTagId(opportunityId, reviewId, tag);
+    const { newTagId, newReviewId } = await request.json();
+
+    if (!newTagId || !newReviewId) {
+      return NextResponse.json({ Error: "New tag ID and review ID are required." }, { status: 400 });
+    }
+
+    const updateResult = await prisma.reviewTag.updateMany({
+      where: {
+        tagId: tagId,
+        reviewId: parseInt(reviewId),
+      },
+      data: {
+        tagId: newTagId,
+        reviewId: newReviewId,
+      },
+    });
+
+    if (updateResult.count === 0) {
+      return NextResponse.json({ Error: "No review tag was updated, check your IDs." }, { status: 404 });
+    }
+
+    return NextResponse.json({ Message: "Review tag updated successfully." }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: error.message }, { status: 500 });
+  }
+};
+
+
+/**
+ * DELETE opportunity/[opportunityId]/review/[reviewId]/ReviewTag/[tag]
+ *
+ * Removes the ReviewTag for a specific Review
+ * 
+ * @param NextRequest request
+ * @param number opportunityId
+ * @param number reviewId
+ * @param string tag
+ * @returns NextResponse
+ */
+export const DELETE = async (
+  request: NextRequest,
+  { params: { opportunityId, reviewId, tag } },
+): Promise<NextResponse> => {
+  try {
+    const tagId = await validateAndFetchTagId(opportunityId, reviewId, tag);
+
+    await prisma.reviewTag.delete({
+      where: {
+        tagId_reviewId: {
+          tagId: tagId,
+          reviewId: parseInt(reviewId),
+        },
+      },
+    });
+
+    return NextResponse.json({ Message: "Review tag deleted successfully." }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: error.message }, { status: error.message.includes("not found") ? 404 : 500 });
+  }
+};
+

--- a/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewTag/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/[reviewId]/reviewTag/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateReviewPhaseRequest } from "../reviewPhase/route";
+import { useRouter } from "next/navigation";
+
+/**
+ * Checks if the review exists.
+ *
+ * @param number reviewId
+ * @returns boolean opportunityExistence
+ */
+export const checkReviewExistence = async (
+  reviewId: number,
+): Promise<boolean> => {
+  const review = await prisma.review
+    .findUnique({
+      where: {
+        id: reviewId,
+      },
+    })
+    .catch((error) => {
+      console.log("Unable to find an review with this id: ", error);
+    });
+
+  return review !== null;
+};
+
+/**
+ * Checks if the opportunity and reviewId are existent. If not, error is thrown.
+ *
+ * @param opportunityId
+ *
+ * @param reviewId
+ * @returns
+ */
+export const validateReviewTagRequest = async (
+  opportunityId: number,
+  reviewId: number,
+): Promise<boolean> => {
+  return validateReviewPhaseRequest(opportunityId, reviewId);
+};
+
+/**
+ * GET opportunity/[opportunityId]/review/[reviewId]/reviewTag
+ * 
+ * Gets all ReviewTags for this Review
+ *
+ * @param NextRequest request
+ * @param number reviewId
+ * @param number opportunityId
+ * @returns ReviewTag[] reviewTag
+ */
+export const GET = async (
+  request: NextRequest,
+  { params: { opportunityId, reviewId } },
+): Promise<NextResponse> => {
+  try {
+    const opportunityIdNum = parseInt(opportunityId);
+    const reviewIdNum = parseInt(reviewId);
+
+    const isValidReviewTagRequest = await validateReviewTagRequest(opportunityIdNum, reviewIdNum);
+    if (!isValidReviewTagRequest) {
+      return NextResponse.json({ Error: "Invalid review or opportunity ID." }, { status: 400 });
+    }
+
+    const reviewTags = await prisma.reviewTag.findMany({
+      where: {
+        reviewId: reviewIdNum,
+      },
+      include: {
+        tag: true,
+      },
+    });
+
+    return NextResponse.json(reviewTags, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+/**
+ * POST opportunity/[opportunityId]/review/[reviewId]/reviewTag
+ * 
+ * Creates a new ReviewTag
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @param number reviewId
+ * @param @async tag - The tag that this ReviewTag points to 
+ * @returns ReviewTag reviewTag
+ */
+export const POST = async (
+  request: NextRequest,
+  { params: { opportunityId, reviewId } },
+): Promise<NextResponse> => {
+  try {
+    const opportunityIdNum = parseInt(opportunityId);
+    const reviewIdNum = parseInt(reviewId);
+    const { tag } = await request.json();
+
+    if (!tag) {
+      return NextResponse.json({ Error: "Tag is required." }, { status: 400 });
+    }
+
+    const isValidReviewTagRequest = await validateReviewTagRequest(opportunityIdNum, reviewIdNum);
+    if (!isValidReviewTagRequest) {
+      return NextResponse.json({ Error: "Invalid review or opportunity ID." }, { status: 400 });
+    }
+
+    const tagRecord = await prisma.tag.findFirst({
+      where: {
+        opportunityId: opportunityIdNum,
+        name: tag,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!tagRecord) {
+      return NextResponse.json({ Error: "Tag not found." }, { status: 404 });
+    }
+
+    const createReviewTag = await prisma.reviewTag.create({
+      data: {
+        tagId: tagRecord.id,
+        reviewId: reviewIdNum,
+      },
+    });
+
+    return NextResponse.json(createReviewTag, { status: 201 }); // Use 201 for creation
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+

--- a/app/app/api/opportunity/[opportunityId]/review/reviewTag/[tag]/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/reviewTag/[tag]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkOpportunityExistence } from "../../route";
+
+/**
+ * GET opportunity/[opportunityId]/review/reviewTag/[tag]
+ *
+ * Fetches all reviews with a specific tag for a given opportunity
+ *
+ * @param NextRequest request
+ * @param string opportunityId
+ * @param string tag - the name of the tag that you're filtering for
+ * @returns NextResponse
+ */
+export const GET = async (
+  request: NextRequest,
+  { params: { opportunityId, tag } },
+): Promise<NextResponse> => {
+  try {
+    const opportunityIdNum = parseInt(opportunityId);
+    if (isNaN(opportunityIdNum)) {
+      return NextResponse.json({ Error: "Invalid opportunity ID." }, { status: 400 });
+    }
+
+    const isOpportunityExistent = await checkOpportunityExistence(opportunityIdNum);
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const reviews = await prisma.review.findMany({
+      where: {
+        opportunityId: opportunityIdNum,
+        reviewTags: {
+          some: {
+            tag: { name: tag },
+          },
+        },
+      },
+      include: {
+        reviewTags: true
+      }
+    });
+
+    if (reviews.length === 0) {
+      return NextResponse.json({ Message: "No reviews found with the specified tag." }, { status: 404 });
+    }
+
+    return NextResponse.json(reviews, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};

--- a/app/app/api/opportunity/[opportunityId]/review/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/review/route.ts
@@ -26,89 +26,81 @@ export const checkOpportunityExistence = async (
 
 /**
  * GET opportunityParticipation/[opportunityId]/review
+ * 
+ * Gets all reviews for a particular opportunity
  *
  * @param NextRequest request
  * @param number opportunityId
- * @returns review[] reviews
+ * @returns NextResponse
  */
 export const GET = async (
   request: NextRequest,
   { params: { opportunityId } },
 ): Promise<NextResponse> => {
   try {
-    const isOpportunityExistent = await checkOpportunityExistence(
-      parseInt(opportunityId),
-    );
+    const opportunityIdNum = parseInt(opportunityId);
+    if (isNaN(opportunityIdNum)) {
+      return NextResponse.json({ Error: "Invalid opportunity ID." }, { status: 400 });
+    }
 
-    const getReviews = await prisma.review.findMany({
+    const isOpportunityExistent = await checkOpportunityExistence(opportunityIdNum);
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const reviews = await prisma.review.findMany({
       where: {
-        opportunityId: parseInt(opportunityId),
+        opportunityId: opportunityIdNum,
       },
     });
 
-    const responseBody =
-      getReviews === null || !isOpportunityExistent
-        ? {
-            Error: "Bad request. The review with this id does not exist.",
-          }
-        : getReviews;
-    const status = getReviews === null || !isOpportunityExistent ? 400 : 200;
-
-    return NextResponse.json(responseBody, { status });
+    return NextResponse.json(reviews, { status: 200 });
   } catch (error) {
-    console.log(error);
-    return NextResponse.json(
-      { Error: "Internal Server Error" },
-      { status: 500 },
-    );
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
   }
 };
 
 /**
  * POST opportunity/[opportunityId]/review
  *
+ * Adds a review to a particular opportunity
+ * 
  * @param NextRequest request
  * @param number opportunityId
- * @returns review review
+ * @param @async application - The application encoded in a JSON
+ * @returns NextResponse
  */
 export const POST = async (
   request: NextRequest,
   { params: { opportunityId } },
 ): Promise<NextResponse> => {
   try {
-    const isOpportunityExistent = await checkOpportunityExistence(
-      parseInt(opportunityId),
-    );
-    const { application } = await request.json();
+    const opportunityIdNum = parseInt(opportunityId);
+    if (isNaN(opportunityIdNum)) {
+      return NextResponse.json({ Error: "Invalid opportunity ID." }, { status: 400 });
+    }
 
-    const createReview = await prisma.review.create({
+    const isOpportunityExistent = await checkOpportunityExistence(opportunityIdNum);
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const { application } = await request.json();
+    if (application === undefined) {
+      return NextResponse.json({ Error: "Application data is required." }, { status: 400 });
+    }
+
+    const review = await prisma.review.create({
       data: {
-        opportunityId: parseInt(opportunityId),
-        application: application,
+        opportunityId: opportunityIdNum,
+        application,
       },
     });
 
-    const responseBody =
-      createReview === null ||
-      !isOpportunityExistent ||
-      application === undefined
-        ? {
-            Error: "Bad request. The review with this id does not exist.",
-          }
-        : createReview;
-    const status =
-      createReview === null ||
-      !isOpportunityExistent ||
-      application === undefined
-        ? 400
-        : 200;
-
-    return NextResponse.json(responseBody, { status });
+    return NextResponse.json(review, { status: 201 });
   } catch (error) {
-    console.log("There was an error creating the review:", error.message);
-    return NextResponse.json(
-      { Error: "Internal server error." },
-      { status: 500 },
-    );
+    console.error("There was an error creating the review:", error.message);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
   }
 };

--- a/app/app/api/opportunity/[opportunityId]/tag/[name]/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/tag/[name]/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkOpportunityExistence } from "../../review/route";
+import { validateReviewTagRequest } from "../../review/[reviewId]/reviewTag/route";
+import { Tag } from "@prisma/client";
+import { isValid } from "date-fns";
+
+/**
+ * GET opportunity/[opportunityId]/tag/[name]
+ *
+ * Gets a specific tag from an opportunity
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @returns NextResponse
+ */
+export const GET = async (request: NextRequest, { params: { opportunityId, name } }): Promise<NextResponse> => {
+  try {
+    const isOpportunityExistent = await checkOpportunityExistence(parseInt(opportunityId));
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const tag = await prisma.tag.findUnique({
+      where: {
+        opportunityId_name: {
+          name,
+          opportunityId: parseInt(opportunityId),
+        },
+      },
+    });
+
+    if (!tag) {
+      return NextResponse.json({ Error: "Tag not found." }, { status: 404 });
+    }
+
+    return NextResponse.json(tag, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+
+/**
+ * PUT opportunity/[opportunityId]/tag/[name]
+ *
+ * Updates a specific tag for an opportunity
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @async @param json newTag - the new name you want to give this tag
+ * @returns NextResponse
+ */
+export const PUT = async (request: NextRequest, { params: { opportunityId, name } }): Promise<NextResponse> => {
+  try {
+    const isOpportunityExistent = await checkOpportunityExistence(parseInt(opportunityId));
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const { newTag } = await request.json();
+    if (!newTag) {
+      return NextResponse.json({ Error: "New tag name is required." }, { status: 400 });
+    }
+
+    const updatedTag = await prisma.tag.update({
+      where: {
+        opportunityId_name: {
+          name,
+          opportunityId: parseInt(opportunityId),
+        },
+      },
+      data: {
+        name: newTag,
+      },
+    });
+
+    return NextResponse.json(updatedTag, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+/**
+ * DELETE opportunity/[opportunityId]/tag/[name]
+ * 
+ * Deletes a particular tag from an opportunity
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @param number name
+ * @returns NextResponse
+ */
+export const DELETE = async (request: NextRequest, { params: { opportunityId, name } }): Promise<NextResponse> => {
+  try {
+    const opportunityExists = await checkOpportunityExistence(parseInt(opportunityId));
+    if (!opportunityExists) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    await prisma.tag.delete({
+      where: {
+        opportunityId_name: {
+          name,
+          opportunityId: parseInt(opportunityId),
+        },
+      },
+    });
+
+    return NextResponse.json({ Message: "Tag deleted successfully." }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ Error: "Tag not found." }, { status: 404 });
+    }
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+

--- a/app/app/api/opportunity/[opportunityId]/tag/route.ts
+++ b/app/app/api/opportunity/[opportunityId]/tag/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkOpportunityExistence } from "../review/route";
+
+/**
+ * GET opportunity/[opportunityId]/tag
+ *
+ * Fetches all tags for a specific opportunity
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @returns NextResponse
+ */
+export const GET = async (
+  request: NextRequest,
+  { params: { opportunityId } },
+): Promise<NextResponse> => {
+  try {
+    const isOpportunityExistent = await checkOpportunityExistence(parseInt(opportunityId));
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const tags = await prisma.tag.findMany({
+      where: {
+        opportunityId: parseInt(opportunityId),
+      },
+    });
+
+    return NextResponse.json(tags, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+/**
+ * POST opportunity/[opportunityId]/tag
+ * 
+ * Adds a tag to an opportunity
+ *
+ * @param NextRequest request
+ * @param number opportunityId
+ * @async @param json name
+ * @async @param json tallyLabel
+ * @returns NextResponse
+ */
+export const POST = async (
+  request: NextRequest,
+  { params: { opportunityId } },
+): Promise<NextResponse> => {
+  try {
+    const { name, tallyLabel } = await request.json();
+
+    if (name === undefined || tallyLabel === undefined) {
+      return NextResponse.json({ Error: "Missing tag name or tally label." }, { status: 400 });
+    }
+
+    const isOpportunityExistent = await checkOpportunityExistence(parseInt(opportunityId));
+    if (!isOpportunityExistent) {
+      return NextResponse.json({ Error: "Opportunity does not exist." }, { status: 404 });
+    }
+
+    const tag = await prisma.tag.create({
+      data: {
+        name,
+        tallyLabel,
+        opportunityId: parseInt(opportunityId),
+      },
+    });
+
+    return NextResponse.json(tag, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    if (error.code === "P2002") {
+      return NextResponse.json({ Error: "Tag already exists." }, { status: 409 });
+    }
+    return NextResponse.json({ Error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+

--- a/app/prisma/migrations/20240201220247_/migration.sql
+++ b/app/prisma/migrations/20240201220247_/migration.sql
@@ -172,6 +172,25 @@ CREATE TABLE "Review" (
 );
 
 -- CreateTable
+CREATE TABLE "Tag" (
+    "id" SERIAL NOT NULL,
+    "opportunityId" INTEGER NOT NULL,
+    "tallyLabel" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ReviewTag" (
+    "id" SERIAL NOT NULL,
+    "reviewId" INTEGER NOT NULL,
+    "tagId" INTEGER NOT NULL,
+
+    CONSTRAINT "ReviewTag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "PhaseReview" (
     "phase" TEXT NOT NULL,
     "reviewId" INTEGER NOT NULL,
@@ -211,6 +230,12 @@ CREATE UNIQUE INDEX "Contact_username_key" ON "Contact"("username");
 CREATE UNIQUE INDEX "OpportunityPermission_name_key" ON "OpportunityPermission"("name");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "Tag_opportunityId_name_key" ON "Tag"("opportunityId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReviewTag_tagId_reviewId_key" ON "ReviewTag"("tagId", "reviewId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "_UserToUserRole_AB_unique" ON "_UserToUserRole"("A", "B");
 
 -- CreateIndex
@@ -229,10 +254,10 @@ ALTER TABLE "UserPermission" ADD CONSTRAINT "UserPermission_role_fkey" FOREIGN K
 ALTER TABLE "Contact" ADD CONSTRAINT "Contact_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Opportunity" ADD CONSTRAINT "Opportunity_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
@@ -241,13 +266,13 @@ ALTER TABLE "Opportunity" ADD CONSTRAINT "Opportunity_creatorId_fkey" FOREIGN KE
 ALTER TABLE "Opportunity" ADD CONSTRAINT "Opportunity_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "OpportunityParticipation" ADD CONSTRAINT "OpportunityParticipation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "OpportunityParticipation" ADD CONSTRAINT "OpportunityParticipation_opportunityId_fkey" FOREIGN KEY ("opportunityId") REFERENCES "Opportunity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "OpportunityParticipation" ADD CONSTRAINT "OpportunityParticipation_role_fkey" FOREIGN KEY ("role") REFERENCES "OpportunityRole"("name") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OpportunityParticipation" ADD CONSTRAINT "OpportunityParticipation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "OpportunityPermission" ADD CONSTRAINT "OpportunityPermission_role_fkey" FOREIGN KEY ("role") REFERENCES "OpportunityRole"("name") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -256,10 +281,19 @@ ALTER TABLE "OpportunityPermission" ADD CONSTRAINT "OpportunityPermission_role_f
 ALTER TABLE "Review" ADD CONSTRAINT "Review_opportunityId_fkey" FOREIGN KEY ("opportunityId") REFERENCES "Opportunity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Tag" ADD CONSTRAINT "Tag_opportunityId_fkey" FOREIGN KEY ("opportunityId") REFERENCES "Opportunity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewTag" ADD CONSTRAINT "ReviewTag_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewTag" ADD CONSTRAINT "ReviewTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "User"("profileId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "_UserToUserRole" ADD CONSTRAINT "_UserToUserRole_A_fkey" FOREIGN KEY ("A") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/prisma/migrations/20240202165352_init/migration.sql
+++ b/app/prisma/migrations/20240202165352_init/migration.sql
@@ -61,7 +61,7 @@ CREATE TABLE "UserPermission" (
 -- CreateTable
 CREATE TABLE "Profile" (
     "id" SERIAL NOT NULL,
-    "userId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
     "birthday" TIMESTAMP(3),
     "nationality" TEXT,
     "description" TEXT,
@@ -194,7 +194,7 @@ CREATE TABLE "ReviewTag" (
 CREATE TABLE "PhaseReview" (
     "phase" TEXT NOT NULL,
     "reviewId" INTEGER NOT NULL,
-    "assigneeId" INTEGER NOT NULL,
+    "assigneeId" TEXT NOT NULL,
     "content" JSONB NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
@@ -290,7 +290,7 @@ ALTER TABLE "ReviewTag" ADD CONSTRAINT "ReviewTag_reviewId_fkey" FOREIGN KEY ("r
 ALTER TABLE "ReviewTag" ADD CONSTRAINT "ReviewTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "User"("profileId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "PhaseReview" ADD CONSTRAINT "PhaseReview_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -63,7 +63,7 @@ model UserPermission {
 
 model Profile {
   id               Int       @id @default(autoincrement())
-  userId           Int
+  userId           String
   birthday         DateTime?
   nationality      String?
   description      String?
@@ -194,11 +194,11 @@ model ReviewTag {
 model PhaseReview {
   phase      String
   reviewId   Int
-  assigneeId Int
+  assigneeId String
   content    Json
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
-  assignee   User     @relation(fields: [assigneeId], references: [profileId])
+  assignee   User     @relation(fields: [assigneeId], references: [id])
   review     Review   @relation(fields: [reviewId], references: [id])
 
   @@id([phase, reviewId], name: "id")

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Account {
   providerAccountId String
   ok                Boolean
   state             String
-  accessToken       String?  @db.Text
+  accessToken       String?
   tokenType         String?
   idToken           String?
   createdAt         DateTime @default(now())
@@ -30,27 +30,27 @@ model Account {
 model User {
   id                       String                     @id @default(cuid())
   profileId                Int?                       @unique
-  profile                  Profile?                   @relation(fields: [profileId], references: [id])
   email                    String                     @unique
   password                 String?
   firstName                String?
   lastName                 String?
   image                    String?
-  userRoles                UserRole[]
-  departmentMemberships    DepartmentMembership[]
-  createdOpportunities     Opportunity[]
-  opportunityParticipation OpportunityParticipation[]
-  reviews                  PhaseReview[]
   emailVerified            DateTime?
   createdAt                DateTime                   @default(now())
   updatedAt                DateTime                   @updatedAt
   accounts                 Account[]
+  departmentMemberships    DepartmentMembership[]
+  createdOpportunities     Opportunity[]
+  opportunityParticipation OpportunityParticipation[]
+  reviews                  PhaseReview[]
+  profile                  Profile?                   @relation(fields: [profileId], references: [id])
+  userRoles                UserRole[]                 @relation("UserToUserRole")
 }
 
 model UserRole {
   name            String           @id
-  users           User[]
   userPermissions UserPermission[]
+  users           User[]           @relation("UserToUserRole")
 }
 
 model UserPermission {
@@ -64,7 +64,6 @@ model UserPermission {
 model Profile {
   id               Int       @id @default(autoincrement())
   userId           Int
-  user             User?
   birthday         DateTime?
   nationality      String?
   description      String?
@@ -75,28 +74,20 @@ model Profile {
   degreeLastUpdate DateTime?
   university       String?
   profilePicture   String?
-  contacts         Contact[]
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
+  contacts         Contact[]
+  user             User?
 }
 
 model Contact {
   id        Int         @id @default(autoincrement())
   profileId Int
-  profile   Profile     @relation(fields: [profileId], references: [id])
   type      ContactType
   username  String      @unique
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
-}
-
-enum ContactType {
-  EMAIL
-  SLACK
-  GITHUB
-  FACEBOOK
-  INSTAGRAM
-  PHONE
+  profile   Profile     @relation(fields: [profileId], references: [id])
 }
 
 model Department {
@@ -104,69 +95,54 @@ model Department {
   name                  String
   type                  DepartmentType
   creationDate          DateTime               @default(now())
-  departmentMemberships DepartmentMembership[]
-  opportunities         Opportunity[]
   createdAt             DateTime               @default(now())
   updatedAt             DateTime               @updatedAt
-}
-
-enum DepartmentType {
-  FUNCTIONAL
-  MISSION_BASED
+  departmentMemberships DepartmentMembership[]
+  opportunities         Opportunity[]
 }
 
 model DepartmentMembership {
   id                 Int                @id @default(autoincrement())
   userId             String?
-  user               User?              @relation(fields: [userId], references: [id], onDelete: SetNull)
   departmentId       Int?
-  department         Department?        @relation(fields: [departmentId], references: [id], onDelete: SetNull)
   membershipStart    DateTime
   membershipEnd      DateTime?
   departmentPosition DepartmentPosition
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
-}
-
-enum DepartmentPosition {
-  PRESIDENT
-  HEAD_OF_DEPARTMENT
-  BOARD_MEMBER
-  ADVISOR
-  TASKFORCE_LEAD
-  PROJECT_LEAD
-  ACTIVE_MEMBER
-  ALUMNI
+  department         Department?        @relation(fields: [departmentId], references: [id])
+  user               User?              @relation(fields: [userId], references: [id])
 }
 
 model Opportunity {
   id                       Int                        @id @default(autoincrement())
   creatorId                String?
-  creator                  User?                      @relation(fields: [creatorId], references: [id], onDelete: SetNull)
   title                    String
   description              String
   configuration            Json
   departmentId             Int
-  department               Department                 @relation(fields: [departmentId], references: [id])
   opportunityStart         DateTime
   opportunityEnd           DateTime?
-  reviews                  Review[]
-  opportunityParticipation OpportunityParticipation[]
   createdAt                DateTime                   @default(now())
   updatedAt                DateTime                   @updatedAt
+  creator                  User?                      @relation(fields: [creatorId], references: [id])
+  department               Department                 @relation(fields: [departmentId], references: [id])
+  opportunityParticipation OpportunityParticipation[]
+  reviews                  Review[]
+  tags                     Tag[]
 }
 
 model OpportunityParticipation {
   userId          String
-  user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   opportunityId   Int
-  opportunity     Opportunity     @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
   role            String
-  opportunityRole OpportunityRole @relation(fields: [role], references: [name])
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
+  opportunity     Opportunity     @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
+  opportunityRole OpportunityRole @relation(fields: [role], references: [name])
+  user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@id(name: "opportunityParticipationId", [userId, opportunityId])
+  @@id([userId, opportunityId], name: "opportunityParticipationId")
 }
 
 model OpportunityRole {
@@ -187,20 +163,68 @@ model Review {
   id            Int           @id @default(autoincrement())
   application   Json
   opportunityId Int
-  opportunity   Opportunity   @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
-  phaseReviews  PhaseReview[]
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
+  phaseReviews  PhaseReview[]
+  opportunity   Opportunity   @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
+  reviewTags    ReviewTag[]
+}
+
+model Tag {
+  id            Int         @id @default(autoincrement())
+  opportunityId Int
+  tallyLabel    String
+  name          String
+  reviewTags    ReviewTag[]
+  opportunity   Opportunity @relation(fields: [opportunityId], references: [id])
+
+  @@unique([opportunityId, name])
+}
+
+model ReviewTag {
+  id       Int    @id @default(autoincrement())
+  reviewId Int
+  tagId    Int
+  review   Review @relation(fields: [reviewId], references: [id])
+  tag      Tag    @relation(fields: [tagId], references: [id])
+
+  @@unique([tagId, reviewId])
 }
 
 model PhaseReview {
   phase      String
   reviewId   Int
-  review     Review @relation(fields: [reviewId], references: [id])
   assigneeId Int
-  assignee   User   @relation(fields: [assigneeId], references: [profileId])
   content    Json
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
-  @@id(name: "id", [phase, reviewId])
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  assignee   User     @relation(fields: [assigneeId], references: [profileId])
+  review     Review   @relation(fields: [reviewId], references: [id])
+
+  @@id([phase, reviewId], name: "id")
+}
+
+enum ContactType {
+  EMAIL
+  SLACK
+  GITHUB
+  FACEBOOK
+  INSTAGRAM
+  PHONE
+}
+
+enum DepartmentType {
+  FUNCTIONAL
+  MISSION_BASED
+}
+
+enum DepartmentPosition {
+  PRESIDENT
+  HEAD_OF_DEPARTMENT
+  BOARD_MEMBER
+  ADVISOR
+  TASKFORCE_LEAD
+  PROJECT_LEAD
+  ACTIVE_MEMBER
+  ALUMNI
 }


### PR DESCRIPTION
This pull request details the creation of CRUD endpoints for review tags and some refactorings. Here are some of the endpoints: 
```
GET/POST api/opportunity/[id]/review/[id]/reviewTag
PUT/DELETE api/opportunity/[id]/review/[id]/reviewTag/[id]

GET api/opportunity/[id]/reviewTag
GET, UPDTE, DELETE api/opportunity/[id]/reviewTag/[id]

GET/POST api/opportunity/tag
GET/UPDATE/DELETE api/opportunity/tag/[name]

Refactoring: 

GET, POST api/opportunity/[id]/review/[id]/reviewPhase
GET, UPDATE, DELETE api/opportunity/[id]/review/[id]/reviewPhase/[phase]

GET, POST api/opportunity/[id]/review

```
Please see the documentation comments for more information.